### PR TITLE
Adjust tests for not using miminal representation

### DIFF
--- a/tests/test_counts.py
+++ b/tests/test_counts.py
@@ -11,7 +11,7 @@ def test_info():
         "id": "GRCh38:beacon_test:2030-01-01",
         "assemblyId": "GRCh38",
         "variantCount": 17,
-        "callCount": 15,
+        "callCount": 12,
         "sampleCount": 2504,
     }]}
     return {}, resp
@@ -261,8 +261,8 @@ def test_snp_mnp():
     """ Test representation of TG->AG and multiple variations from one vcf line """
     query = base()
     query['start'] = 16577044
-    query['end'] = 16577045
-    query['referenceBases'] = 'T'
+    query['end'] = 16577046
+    query['referenceBases'] = 'TG'
     del query['alternateBases']
     query['variantType'] = 'SNP'
     resp = {"datasetAlleleResponses": [
@@ -272,8 +272,8 @@ def test_snp_mnp():
          "variantCount": 17,
          "sampleCount": 2504,
          "exists": True,
-         "referenceBases": "T",
-         "alternateBases": "A",
+         "referenceBases": "TG",
+         "alternateBases": "AG",
          "variantType": "SNP",
          "frequency": 0.003394569
          }]}
@@ -295,8 +295,8 @@ def test_multi():
          "variantCount": 17,
          "sampleCount": 2504,
          "exists": True,
-         "referenceBases": "G",
-         "alternateBases": "GTCTTCT",
+         "referenceBases": "GTCT",
+         "alternateBases": "GTCTTCTTCT",
          "variantType": "INS",
          "frequency": 0.00339457
         },
@@ -306,8 +306,8 @@ def test_multi():
          "variantCount": 118,
          "sampleCount": 2504,
          "exists": True,
-         "referenceBases": "G",
-         "alternateBases": "GTCT",
+         "referenceBases": "GTCT",
+         "alternateBases": "GTCTTCT",
          "variantType": "INS",
          "frequency": 0.0235623
         },

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -9,8 +9,8 @@ def test_two_datasets():
     """Test that both datasets repsond."""
     query = base()
     query['start'] = 16577044
-    query['end'] = 16577045
-    query['referenceBases'] = 'T'
+    query['end'] = 16577046
+    query['referenceBases'] = 'TG'
     del query['alternateBases']
     query['variantType'] = 'SNP'
     del query['datasetIds']
@@ -21,8 +21,8 @@ def test_two_datasets():
          "variantCount": 17,
          "sampleCount": 2504,
          "exists": True,
-         "referenceBases": "T",
-         "alternateBases": "A",
+         "referenceBases": "TG",
+         "alternateBases": "AG",
          "variantType": "SNP",
          "frequency": 0.003394569
          },
@@ -30,11 +30,11 @@ def test_two_datasets():
          "referenceName": "22",
          "externalUrl": "www.beacon.com",
          "exists": True,
-         "referenceBases": "T",
-         "alternateBases": "A",
+         "referenceBases": "TG",
+         "alternateBases": "AG",
          "variantType": "SNP",
          "start": 16577043,
-         "end": 16577044,
+         "end": 16577045,
          "frequency": 0.003394569,
          "variantCount": 17,
          "callCount": 5008,
@@ -64,13 +64,13 @@ def test_datasets_info():
         {"id": "GRCh38:beacon_test:2030-01-01",
          "assemblyId": "GRCh38",
          "variantCount": 17,
-         "callCount": 15,
+         "callCount": 12,
          "sampleCount": 2504
          },
         {"id": "GRCh38:beacon_test2:2030-01-01",
          "assemblyId": "GRCh38",
          "variantCount": 4,
-         "callCount": 4,
+         "callCount": 2,
          "sampleCount": 2504
          }]}
     return {}, resp


### PR DESCRIPTION
Tests no longer assume that the variants are presented in their minimal form
(eg, don't trim `TG>AG` to `T>A`).  Matches the changes made in  https://github.com/NBISweden/swefreq/pull/546.

Adjust counts and bases for this.