### PR TITLE
Improve output

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,8 +1,8 @@
 """Configurations for the tests."""
 
 # Path to the OpenAPI spec
-# SPEC = ''
-SPEC = 'beacon.yaml'
+SPEC = ''
+# SPEC = 'beacon.yaml'
 
 # Lists of hosts to test
 HOSTS = {
@@ -15,8 +15,8 @@ HOSTS = {
 }
 
 # Directory containing JSON schemas
-# SCHEMAS = ''
-SCHEMAS = 'schemas'
+SCHEMAS = ''
+# SCHEMAS = 'schemas'
 
 #  Floats are rounded in comparisions, set the precision (number of digits) here
 PRECISION = 6

--- a/tests/v101/test_counts.py
+++ b/tests/v101/test_counts.py
@@ -84,7 +84,7 @@ def test_bad_end():
     query['referenceBases'] = 'A'
     query['alternateBases'] = 'G'
     resp = call_beacon(query=query)
-    assert not resp['exists'], 'Beacon found match for bad query'
+    assert 'exists' in resp and not resp['exists'], 'Beacon did not report "exist: False" for a bad query'
 
 
 @run_test()

--- a/utils/beacon_query.py
+++ b/utils/beacon_query.py
@@ -43,12 +43,12 @@ def validate(req, resp, path, query):
         # check that the query complies to the api spec
         validator = RequestValidator(settings.openapi)
         result = validator.validate(req)
-        warnings.extend(result.errors)
+        warnings.extend(['OpenApi: ' + x for x in result.errors])
 
         # check that the response complies to the api spec
         validator = ResponseValidator(settings.openapi)
         result = validator.validate(req, resp)
-        warnings.extend(result.errors)
+        warnings.extend(['OpenAPI: ' + str(x) for x in result.errors])
 
     if settings.use_json_schemas:
         if path != '/' and query is not None:

--- a/utils/jsonschemas.py
+++ b/utils/jsonschemas.py
@@ -46,10 +46,10 @@ def validate(inp, inp_type, settings, path=''):
         logging.warning('No JSON schema for %s, not validating', schema)
         return []
 
-    validator = jsonschema.Draft4Validator(jschema)
+    validator = jsonschema.Draft4Validator(jschema) #, format_checker=jsonschema.FormatChecker())
     logging.info('Validate JSON to schema %s', schema)
     for err in validator.iter_errors(inp, jschema):
         # join path, skipping list indices
         path = '.'.join([p for p in err.path if isinstance(p, str)])
-        errs.append(f"JSON schema, field '{path}': " + err.message)
+        errs.append(f"JSON schema: field '{path}': " + err.message)
     return errs

--- a/utils/jsonschemas.py
+++ b/utils/jsonschemas.py
@@ -46,7 +46,7 @@ def validate(inp, inp_type, settings, path=''):
         logging.warning('No JSON schema for %s, not validating', schema)
         return []
 
-    validator = jsonschema.Draft4Validator(jschema) #, format_checker=jsonschema.FormatChecker())
+    validator = jsonschema.Draft4Validator(jschema)  # , format_checker=jsonschema.FormatChecker())
     logging.info('Validate JSON to schema %s', schema)
     for err in validator.iter_errors(inp, jschema):
         # join path, skipping list indices

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -16,7 +16,7 @@ import utils.errors as err
 
 
 VERSIONS = {'v101': {'ga4gh': 'v1.0.1', 'CSCfi': 'v1.1.0-rc1'},
-            'v110': {'ga4gh': 'develop', 'CSCfi': 'v1.2.0-rc0'}
+            'v110': {'ga4gh': 'develop', 'CSCfi': 'v1.3.0-rc0'}
             }
 
 

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -46,6 +46,7 @@ class Settings():
     json_schemas = {}
     openapi = None
     host = None
+    version = None
 
     def __init__(self):
         """Initialize."""


### PR DESCRIPTION
- Don't set default paths for the schemas, download them instead
- State who's giving the warnings (OpenAPI or JSONSchemas)
- Use latest version of the CSCfi's schemas
