### PR TITLE
Update yaml files

### DIFF
--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -42,7 +42,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 1
         sampleCount: 2504
@@ -67,7 +67,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 2931
         sampleCount: 2504
@@ -107,7 +107,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 4723
         sampleCount: 2504
@@ -132,7 +132,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 21
         sampleCount: 2504
@@ -156,7 +156,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 7
         sampleCount: 2504
@@ -182,7 +182,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 116
         sampleCount: 2504
@@ -195,7 +195,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 314
         sampleCount: 2504
@@ -221,7 +221,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 4
         sampleCount: 2504
@@ -246,7 +246,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 3
         sampleCount: 2504
@@ -275,7 +275,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 2932
         sampleCount: 2504
@@ -289,18 +289,18 @@
   descr:
     Test representation of TG->AG and multiple variations from one vcf line.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16577043
     end: 16577045
     referenceBases: TG
     alternateBases: null
     variantType: SNP
-  Results:
+  results:
     - property: datasetAlleleResponses
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 17
         sampleCount: 2504
@@ -314,17 +314,17 @@
   descr:
     Test alternateBases=N and multiple variations from one vcf line (indel).
   query:
-    <<: &default_query
+    <<: *default_query
     start: 19617926
     end: null
     referenceBases: N
     alternateBases: N
-  Results:
+  results:
     - property: datasetAlleleResponses
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 17
         sampleCount: 2504
@@ -337,7 +337,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 118
         sampleCount: 2504
@@ -350,7 +350,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 182
         sampleCount: 2504

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -2,11 +2,10 @@
 # Example tests.
 # Check that they work and that we get the expected output.
 ---
-- name: test_info
-  descr:
-    Test the beacon's info (/) call.
+- name: default query
+  skip: true
   query: &default_query
-    referenceName: 22
+    referenceName: "22"
     referenceBases: GG
     alternateBases: N
     assemblyId: GRCh38
@@ -15,6 +14,10 @@
     includeDatasetResponses: HIT
     datasetIds:
       - GRCh38:beacon_test:2030-01-01
+
+- name: test_info
+  descr:
+    Test the beacon's info (/) endpoint.
   results:
     - property: datasets
       assert: contains

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -118,7 +118,7 @@
   descr:
     Test variantTypes INS.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16064512
     end: 16064513
     variantType: INS
@@ -143,7 +143,7 @@
   descr:
     Test variantTypes by searching for ref and alt.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16539540
     end: 16539541
     referenceBases: A
@@ -168,7 +168,7 @@
     Find a variantTypes INS at a position where there are two different
     variants.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16879600
     end: 16879601
     referenceBases: T
@@ -206,7 +206,7 @@
   descr:
     Test a deletion by searching for ref and alt.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16497140
     end: 16497143
     referenceBases: CTT
@@ -232,7 +232,7 @@
   descr:
     Test variantTypes DEL.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16517679
     end: 16517684
     referenceBases: GACAA
@@ -257,7 +257,7 @@
   descr:
     Test variantTypes DEL with startMin/startMax.
   query:
-    <<: &default_query
+    <<: *default_query
     start: null
     end: null
     startMin: 17301520

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -87,11 +87,8 @@
     referenceBases: A
     alternateBases: G
   results:
-    # FIXME: I'm unsure of how to formulate this.
-    - property: datasetAlleleResponses
-      assert: contains
-      data:
-        exists: null
+    - property: exists
+      assert: isfalse
 
 - name: test_end
   descr:

--- a/tests/test-v101-datasets.yaml
+++ b/tests/test-v101-datasets.yaml
@@ -5,17 +5,22 @@
 #   test_datasets_info():
 #   I don't quite know how to translate a call_beacon(path='/') query.
 ---
-- name: test_two_datasets
-  descr:
-    Test that both datasets respond.
+- name: default query
+  skip: true
   query: &default_query
     start: 16577043
     end: 16577043
     referenceBases: TG
     variantType: SNP
     assemblyId: GRCh38
-    referenceName: 22
+    referenceName: "22"
     includeDatasetResponses: HIT
+
+- name: test_two_datasets
+  descr:
+    Test that both datasets respond.
+  query:
+    <<: *default_query
   results:
     - property: datasetAlleleResponses
       assert: length_gt
@@ -24,7 +29,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 17
         sampleCount: 2504
@@ -37,7 +42,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         exists: true
         referenceBases: TG
         alternateBases: AG

--- a/tests/test-v101-datasets.yaml
+++ b/tests/test-v101-datasets.yaml
@@ -2,7 +2,7 @@
 # Tests for more than one dataset.
 #
 # TODO:
-#   test_datasets_info(): 
+#   test_datasets_info():
 #   I don't quite know how to translate a call_beacon(path='/') query.
 ---
 - name: test_two_datasets
@@ -53,7 +53,7 @@
 - name: test_second_datasets
   descr:
     Test that excluding a dataset works.
-  query: 
+  query:
     <<: *default_query
     start: 16577043
     end: 16577045

--- a/tests/test-v101-datasets.yaml
+++ b/tests/test-v101-datasets.yaml
@@ -7,7 +7,7 @@
 ---
 - name: test_two_datasets
   descr:
-    Test that both datasets repsond.
+    Test that both datasets respond.
   query: &default_query
     start: 16577043
     end: 16577043
@@ -15,7 +15,6 @@
     variantType: SNP
     assemblyId: GRCh38
     referenceName: 22
-    referenceBases: GG
     includeDatasetResponses: HIT
   results:
     - property: datasetAlleleResponses

--- a/tests/test-v110-mate.yaml
+++ b/tests/test-v110-mate.yaml
@@ -23,7 +23,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 2
+        referenceName: "2"
         exists: true
         referenceBases: G
         alternateBases: G
@@ -32,7 +32,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 13
+        referenceName: "13"
         exists: true
         referenceBases: A
         alternateBases: A
@@ -59,7 +59,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 13
+        referenceName: "13"
         exists: true
         referenceBases: A
         alternateBases: A

--- a/tests/v110/test_mate.py
+++ b/tests/v110/test_mate.py
@@ -31,7 +31,7 @@ def test_search_1():
              "variantType": "BND"
              }
     assert len(resp.get("datasetAlleleResponses", [])) == 2, \
-        f'All datasets not in response. Expected 2, found {len(resp.get("datasetAlleleResponses", []))}'
+        f'All allele responses not in response. Expected 2, found {len(resp.get("datasetAlleleResponses", []))}'
     assert_partly_in(gold, resp, 'datasetAlleleResponses')
     assert_partly_in(gold2, resp, 'datasetAlleleResponses')
 


### PR DESCRIPTION
### Straightforward stuff
- Use strings for  `referenceName`
- Fix old typo in error message
- 9a89196: Unless I'm missing something, the syntax for  references was mixed up in the `test-v101-counts.yaml`

### Other stuff, to discuss

- ab4226b: The tests call two endpoints: `/query` and `/info`. As it is from this commit, `/query` is called whenever the key `query` is given in a `yaml` test. Therefore, the default query is moved out of the first test (which should make a call to `/info`). In this commit, a new key is introduced (`skip`), which skips the current object/test.
- 5060f0b: To fix the [`FIXME`](https://github.com/NBISweden/beacon-api-tests/blob/04ac53082a7ce8bc0bedd3a8d69a7309ce8ec2f6/tests/test-v101-counts.yaml#L87), a new value for `assert` is introduced: `isfalse`.

