### PR TITLE
Code for running yaml tests

### DIFF
--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -42,7 +42,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 1
         sampleCount: 2504
@@ -67,7 +67,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 2931
         sampleCount: 2504
@@ -107,7 +107,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 4723
         sampleCount: 2504
@@ -132,7 +132,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 21
         sampleCount: 2504
@@ -156,7 +156,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 7
         sampleCount: 2504
@@ -182,7 +182,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 116
         sampleCount: 2504
@@ -195,7 +195,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 314
         sampleCount: 2504
@@ -221,7 +221,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 4
         sampleCount: 2504
@@ -246,7 +246,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 3
         sampleCount: 2504
@@ -275,7 +275,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 2932
         sampleCount: 2504
@@ -289,18 +289,18 @@
   descr:
     Test representation of TG->AG and multiple variations from one vcf line.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16577043
     end: 16577045
     referenceBases: TG
     alternateBases: null
     variantType: SNP
-  Results:
+  results:
     - property: datasetAlleleResponses
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 17
         sampleCount: 2504
@@ -314,17 +314,17 @@
   descr:
     Test alternateBases=N and multiple variations from one vcf line (indel).
   query:
-    <<: &default_query
+    <<: *default_query
     start: 19617926
     end: null
     referenceBases: N
     alternateBases: N
-  Results:
+  results:
     - property: datasetAlleleResponses
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 17
         sampleCount: 2504
@@ -337,7 +337,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 118
         sampleCount: 2504
@@ -350,7 +350,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 22
+        referenceName: "22"
         callCount: 5008
         variantCount: 182
         sampleCount: 2504

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -2,11 +2,10 @@
 # Example tests.
 # Check that they work and that we get the expected output.
 ---
-- name: test_info
-  descr:
-    Test the beacon's info (/) call.
+- name: default query
+  skip: true
   query: &default_query
-    referenceName: 22
+    referenceName: "22"
     referenceBases: GG
     alternateBases: N
     assemblyId: GRCh38
@@ -15,6 +14,10 @@
     includeDatasetResponses: HIT
     datasetIds:
       - GRCh38:beacon_test:2030-01-01
+
+- name: test_info
+  descr:
+    Test the beacon's info (/) endpoint.
   results:
     - property: datasets
       assert: contains

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -118,7 +118,7 @@
   descr:
     Test variantTypes INS.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16064512
     end: 16064513
     variantType: INS
@@ -143,7 +143,7 @@
   descr:
     Test variantTypes by searching for ref and alt.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16539540
     end: 16539541
     referenceBases: A
@@ -168,7 +168,7 @@
     Find a variantTypes INS at a position where there are two different
     variants.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16879600
     end: 16879601
     referenceBases: T
@@ -206,7 +206,7 @@
   descr:
     Test a deletion by searching for ref and alt.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16497140
     end: 16497143
     referenceBases: CTT
@@ -232,7 +232,7 @@
   descr:
     Test variantTypes DEL.
   query:
-    <<: &default_query
+    <<: *default_query
     start: 16517679
     end: 16517684
     referenceBases: GACAA
@@ -257,7 +257,7 @@
   descr:
     Test variantTypes DEL with startMin/startMax.
   query:
-    <<: &default_query
+    <<: *default_query
     start: null
     end: null
     startMin: 17301520

--- a/tests/test-v101-counts.yaml
+++ b/tests/test-v101-counts.yaml
@@ -87,11 +87,8 @@
     referenceBases: A
     alternateBases: G
   results:
-    # FIXME: I'm unsure of how to formulate this.
-    - property: datasetAlleleResponses
-      assert: contains
-      data:
-        exists: null
+    - property: exists
+      assert: isfalse
 
 - name: test_end
   descr:

--- a/tests/test-v110-mate.yaml
+++ b/tests/test-v110-mate.yaml
@@ -23,7 +23,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 2
+        referenceName: "2"
         exists: true
         referenceBases: G
         alternateBases: G
@@ -32,7 +32,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 13
+        referenceName: "13"
         exists: true
         referenceBases: A
         alternateBases: A
@@ -59,7 +59,7 @@
       assert: contains
       data:
         datasetId: GRCh38:beacon_test:2030-01-01
-        referenceName: 13
+        referenceName: "13"
         exists: true
         referenceBases: A
         alternateBases: A

--- a/tests/v110/test_mate.py
+++ b/tests/v110/test_mate.py
@@ -31,7 +31,7 @@ def test_search_1():
              "variantType": "BND"
              }
     assert len(resp.get("datasetAlleleResponses", [])) == 2, \
-        f'All datasets not in response. Expected 2, found {len(resp.get("datasetAlleleResponses", []))}'
+        f'All allele responses not in response. Expected 2, found {len(resp.get("datasetAlleleResponses", []))}'
     assert_partly_in(gold, resp, 'datasetAlleleResponses')
     assert_partly_in(gold2, resp, 'datasetAlleleResponses')
 

--- a/utils/compare.py
+++ b/utils/compare.py
@@ -1,37 +1,13 @@
 """Responsible for comparing the responses to the given gold standard."""
-import logging
 import config.config
 import utils.errors as err
-import utils.setup
 
 
 # Define what keys that should be used to sort lists of dictionaries
-SORT_BY = {'datasets': ['id'], 'datasetAlleleResponses': ['datasetId', 'frequency', 'referenceBases']}
-
-
-def run_test():
-    """Decorator for test queries.
-
-    Run the decorated function and catch and log its errors.
-    """
-    def decorator(func):
-        logging.info('Testing %s\n\t%s', func.__name__, func.__doc__.strip())
-        settings = utils.setup.Settings()
-        try:
-            func()
-        except err.ResponseError as r_error:
-            # errors from the comparisons of a response, contains a list of errors to report
-            logging.error('Test "%s" did not pass: """%s"""', func.__name__, func.__doc__.strip())
-            for err_msg in r_error.messages:
-                settings.errors += 1
-                logging.error(err_msg)
-        except AssertionError as a_error:
-            # other errors
-            logging.error('Test "%s" did not pass: """%s"""', func.__name__, func.__doc__.strip())
-            logging.error(str(a_error))
-            settings.errors += 1
-        logging.info('Done\n')
-    return decorator
+SORT_BY = {
+    'datasets': ['id'],
+    'datasetAlleleResponses': ['datasetId', 'frequency', 'referenceBases']
+}
 
 
 def assert_partly_in(gold, response, key):

--- a/utils/run_test.py
+++ b/utils/run_test.py
@@ -1,0 +1,65 @@
+"""Module for running tests, specified in yml."""
+
+import logging
+
+from utils.beacon_query import call_beacon
+import utils.errors as err
+from utils.compare import assert_partly_in, assert_not_in
+import utils.setup
+
+
+def run_test(test):
+    """Call the beacon as specified in the test and check the result."""
+    logging.info(f"Running test {test['name']}")
+    logging.debug(f"{test.get('descr', '')}")
+    logging.debug(f"Assuming that this data is present in your beacon: {test.get('data', [])}")
+    settings = utils.setup.Settings()
+    if test.get('skip', False):
+        return
+    try:
+        if 'query' not in test:
+            resp = call_beacon(path='/')
+        else:
+            resp = call_beacon(query=prepare_query(test['query']))
+
+        for check in test['results']:
+            assert_test(check, resp)
+
+    except err.ResponseError as r_error:
+        # errors from the comparisons of a response, contains a list of errors to report
+        logging.error('Test "%s" did not pass: """%s"""', test['name'], test['descr'])
+        for err_msg in r_error.messages:
+            settings.errors += 1
+            logging.error(err_msg)
+
+    except AssertionError as a_error:
+        # other errors
+        logging.error('Test "%s" did not pass: """%s"""', test['name'], test['descr'])
+        logging.error(str(a_error))
+        settings.errors += 1
+
+
+def assert_test(check, response):
+    """Test one property."""
+    assert check['property'] in response, f"{check['property']} not found in response"
+    if check["assert"] == "isfalse":
+        assert not response[check['property']], f"{check['property']} should be false"
+
+    if check["assert"] == "length_eq":
+        assert len(response[check['property']]) == check['count'], \
+            f"Bad length of field {check['property']}" \
+            f"should be {check['count']}, but is {len(response[check['property']])}"
+
+    if check["assert"] == "contains":
+        assert_partly_in(check['data'], response, check['property'])
+
+    if check["assert"] == "not_contains":
+        assert_not_in(check['data'], response, check['property'])
+
+
+def prepare_query(query):
+    """Remove all null values from the query."""
+    empties = [key for (key, val) in query.items() if val is None]
+    for key in empties:
+        del query[key]
+    return query

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -70,9 +70,7 @@ class Settings():
 
         for pathname in c_args.test:
             with open(pathname) as stream:
-                self.tests += [load_test_config(stream)]
-
-        print(self.tests)
+                self.tests += load_test_config(stream)
 
         self.check_result = not c_args.only_structure
         self.start_pos = int(c_args.one_based)

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -142,6 +142,7 @@ def parse_spec(inp_file):
         raise err.BeaconTestError()
     return spec
 
+
 def load_test_config(pathname):
-    """Load a test YAML file"""
+    """Load a test YAML file."""
     return yaml.load(pathname, Loader=yaml.SafeLoader)


### PR DESCRIPTION
(depends on #34)

Commits:
- f45fb6c  Run yaml tests, skip all python tests
- e9d27a0 Remove unused code, add newlines etc.

To run:
 `python beacon_api_tester.py  --test tests/test-v101-counts.yaml`

Note that we do not need to read the data field from the yaml here, as all data should have been loaded into the beacon's database earlier (by external tools).

TODOs:
- The yaml-files should be validated at some point, so that we can assume that all necessary information are there when we run the tests.
- The unittests for the api-tester need to be updated.

